### PR TITLE
Add DCAN

### DIFF
--- a/configs/dcan/default.yml
+++ b/configs/dcan/default.yml
@@ -42,13 +42,14 @@ model:
           dropout: 0.2
         freeze_layer: true
     add_emb_size_to_channel_sizes: true
-    conv_channel_sizes: [[600, 600], [600, 600]]
+    conv_channel_sizes: [[600, 600], [600, 600, 600]]
     kernel_sizes: [[2, 2], [2, 2]]
     strides: [[1, 1], [1, 1]]
-    dilation_sizes: [[1, 1], [1, 1]]            # 2^(temporal_conv_net_level)
-    paddings: [[2, 2], [2, 2]]                  # (kernel_size - 1) * dilation_size
+    dilations: [[1, 1], [1, 1]]                 # 2^(temporal_conv_net_level)
+    paddings: [[1, 1], [1, 1]]                  # (kernel_size - 1) * dilation_size
     dropouts: [[0.2, 0.2], [0.2, 0.2]]
     weight_norm: true
+    projection_size: 300
     activation: "relu"
     pad_token: "<pad>"
     unk_token: "<unk>"

--- a/configs/dcan/default.yml
+++ b/configs/dcan/default.yml
@@ -1,0 +1,129 @@
+paths:
+  mimic_dir: &mimic_dir datasets/mimic3/csv
+  static_dir: &static_dir datasets/mimic3/static
+  dataset_dir: &dataset_dir datasets/mimic3_50
+  word2vec_dir: &word2vec_dir datasets/mimic3_50/word2vec
+  output_dir: &output_dir results/CAML_mimic3_50
+
+dataset:
+  name: base_dataset
+  data_common: &data_common
+    column_names:
+      hadm_id: "HADM_ID"
+      clinical_note: "TEXT"
+      labels: "LABELS"
+    word2vec_dir: *word2vec_dir
+    pad_token: "<pad>"
+    unk_token: "<unk>"
+    dataset_dir: *dataset_dir
+    label_file: labels.json
+  params:
+    train:
+      <<: *data_common
+      data_file: train.json
+    val:
+      <<: *data_common
+      data_file: val.json
+    test:
+      <<: *data_common
+      data_file: test.json
+
+model:
+  name: dcan
+  params:
+    dataset_dir: *dataset_dir
+    mimic_dir: *mimic_dir
+    static_dir: *static_dir
+    num_classes: 50
+    word_representation_layer:
+      params:
+        init_params:
+          embed_dir: *word2vec_dir
+          dropout: 0.2
+        freeze_layer: true
+    add_emb_size_to_channel_sizes: true
+    conv_channel_sizes: [[600, 600], [600, 600]]
+    kernel_sizes: [[2, 2], [2, 2]]
+    strides: [[1, 1], [1, 1]]
+    dilation_sizes: [[1, 1], [1, 1]]            # 2^(temporal_conv_net_level)
+    paddings: [[2, 2], [2, 2]]                  # (kernel_size - 1) * dilation_size
+    dropouts: [[0.2, 0.2], [0.2, 0.2]]
+    weight_norm: true
+    activation: "relu"
+    pad_token: "<pad>"
+    unk_token: "<unk>"
+
+trainer:
+  name: base_trainer
+  params:
+    output_dir: *output_dir
+    data_loader:
+      batch_size: 16
+      num_workers: 4
+      shuffle: false
+      drop_last: true
+    loss:
+      name: BinaryCrossEntropyLoss
+      params: null
+    optimizer:
+      name: adam
+      params:
+        lr: 0.0001
+        weight_decay: 0.0
+    max_epochs: 200
+    lr_scheduler: null
+    stopping_criterion:
+      metric:
+        name: prec_at_8
+      desired: max
+      patience: 10
+    checkpoint_saver:
+      name: base_saver
+      params:
+        checkpoint_dir: *output_dir
+        interval: 1
+        max_to_keep: 5
+        ckpt_fname_format: "ckpt-{}.pth"
+        best_fname_format: "best-{}.pth"
+        metric:
+          name: prec_at_8
+          class: prec_at_k
+          params:
+            k: 8
+        desired: max
+    eval_metrics: &eval_metrics
+      - name: prec_at_5
+        class: prec_at_k
+        params:
+          k: 5
+      - name: prec_at_8
+        class: prec_at_k
+        params:
+          k: 8
+      - name: macro_f1
+      - name: micro_f1
+      - name: macro_auc
+      - name: micro_auc
+    graph:
+      writer:
+        name: tensorboard
+        params:
+          log_dir: *output_dir
+      train:
+        interval: 100
+        interval_unit: step
+        metric:
+          - name: loss
+      val:
+        interval: 1
+        interval_unit: epoch
+        metric:
+          - name: loss
+          - name: prec_at_5
+          - name: prec_at_8
+          - name: macro_f1
+          - name: micro_f1
+          - name: macro_auc
+          - name: micro_auc
+    seed: 1337
+    use_gpu: true

--- a/configs/dcan/mimic3_50.yml
+++ b/configs/dcan/mimic3_50.yml
@@ -59,7 +59,7 @@ trainer:
       shuffle: false
       drop_last: true
     loss:
-      name: BinaryCrossEntropyLoss
+      name: BinaryCrossEntropyWithLabelSmoothingLoss
       params: null
     optimizer:
       name: adam

--- a/configs/dcan/mimic3_50.yml
+++ b/configs/dcan/mimic3_50.yml
@@ -3,7 +3,7 @@ paths:
   static_dir: &static_dir datasets/mimic3/static
   dataset_dir: &dataset_dir datasets/mimic3_50
   word2vec_dir: &word2vec_dir datasets/mimic3_50/word2vec
-  output_dir: &output_dir results/CAML_mimic3_50
+  output_dir: &output_dir results/dcan_mimic3_50
 
 dataset:
   name: base_dataset

--- a/configs/dcan/mimic3_50.yml
+++ b/configs/dcan/mimic3_50.yml
@@ -39,12 +39,12 @@ model:
           dropout: 0.2
         freeze_layer: true
     add_emb_size_to_channel_sizes: true
-    conv_channel_sizes: [[600, 600]]
-    kernel_sizes: [[2, 2]]
-    strides: [[1, 1]]
-    dilations: [[1, 1]]                         # 2^(temporal_conv_net_level)
-    paddings: [[1, 1]]                          # (kernel_size - 1) * dilation_size
-    dropouts: [[0.2, 0.2]]
+    conv_channel_sizes: [[600, 600], [600, 600, 600]]
+    kernel_sizes: [[2, 2], [2, 2]]
+    strides: [[1, 1], [1, 1]]
+    dilations: [[1, 1], [2, 2]]                 # 2^(temporal_conv_net_level)
+    paddings: [[1, 1], [2, 2]]                  # (kernel_size - 1) * dilation_size
+    dropouts: [[0.2, 0.2], [0.2, 0.2]]
     weight_norm: true
     projection_size: 300
     activation: "relu"

--- a/configs/dcan/mimic3_50.yml
+++ b/configs/dcan/mimic3_50.yml
@@ -39,12 +39,12 @@ model:
           dropout: 0.2
         freeze_layer: true
     add_emb_size_to_channel_sizes: true
-    conv_channel_sizes: [[600, 600], [600, 600, 600]]
-    kernel_sizes: [[2, 2], [2, 2]]
-    strides: [[1, 1], [1, 1]]
-    dilations: [[1, 1], [1, 1]]                 # 2^(temporal_conv_net_level)
-    paddings: [[1, 1], [1, 1]]                  # (kernel_size - 1) * dilation_size
-    dropouts: [[0.2, 0.2], [0.2, 0.2]]
+    conv_channel_sizes: [[600, 600]]
+    kernel_sizes: [[2, 2]]
+    strides: [[1, 1]]
+    dilations: [[1, 1]]                         # 2^(temporal_conv_net_level)
+    paddings: [[1, 1]]                          # (kernel_size - 1) * dilation_size
+    dropouts: [[0.2, 0.2]]
     weight_norm: true
     projection_size: 300
     activation: "relu"

--- a/configs/dcan/mimic3_50.yml
+++ b/configs/dcan/mimic3_50.yml
@@ -67,7 +67,7 @@ trainer:
       params:
         lr: 0.0001
         weight_decay: 0.0
-    max_epochs: 200
+    max_epochs: 23
     lr_scheduler: null
     stopping_criterion:
       metric:

--- a/configs/dcan/mimic3_50.yml
+++ b/configs/dcan/mimic3_50.yml
@@ -1,0 +1,125 @@
+paths:
+  mimic_dir: &mimic_dir datasets/mimic3/csv
+  static_dir: &static_dir datasets/mimic3/static
+  dataset_dir: &dataset_dir datasets/mimic3_50
+  word2vec_dir: &word2vec_dir datasets/mimic3_50/word2vec
+  output_dir: &output_dir results/CAML_mimic3_50
+
+dataset:
+  name: base_dataset
+  data_common: &data_common
+    column_names:
+      hadm_id: "HADM_ID"
+      clinical_note: "TEXT"
+      labels: "LABELS"
+    word2vec_dir: *word2vec_dir
+    pad_token: "<pad>"
+    unk_token: "<unk>"
+    dataset_dir: *dataset_dir
+    label_file: labels.json
+  params:
+    train:
+      <<: *data_common
+      data_file: train.json
+    val:
+      <<: *data_common
+      data_file: val.json
+    test:
+      <<: *data_common
+      data_file: test.json
+
+model:
+  name: dcan
+  params:
+    num_classes: 50
+    word_representation_layer:
+      params:
+        init_params:
+          embed_dir: *word2vec_dir
+          dropout: 0.2
+        freeze_layer: true
+    add_emb_size_to_channel_sizes: true
+    conv_channel_sizes: [[600, 600], [600, 600, 600]]
+    kernel_sizes: [[2, 2], [2, 2]]
+    strides: [[1, 1], [1, 1]]
+    dilations: [[1, 1], [1, 1]]                 # 2^(temporal_conv_net_level)
+    paddings: [[1, 1], [1, 1]]                  # (kernel_size - 1) * dilation_size
+    dropouts: [[0.2, 0.2], [0.2, 0.2]]
+    weight_norm: true
+    projection_size: 300
+    activation: "relu"
+
+trainer:
+  name: base_trainer
+  params:
+    output_dir: *output_dir
+    data_loader:
+      batch_size: 16
+      num_workers: 4
+      shuffle: false
+      drop_last: true
+    loss:
+      name: BinaryCrossEntropyLoss
+      params: null
+    optimizer:
+      name: adam
+      params:
+        lr: 0.0001
+        weight_decay: 0.0
+    max_epochs: 200
+    lr_scheduler: null
+    stopping_criterion:
+      metric:
+        name: prec_at_8
+      desired: max
+      patience: 10
+    checkpoint_saver:
+      name: base_saver
+      params:
+        checkpoint_dir: *output_dir
+        interval: 1
+        max_to_keep: 5
+        ckpt_fname_format: "ckpt-{}.pth"
+        best_fname_format: "best-{}.pth"
+        metric:
+          name: prec_at_8
+          class: prec_at_k
+          params:
+            k: 8
+        desired: max
+    eval_metrics: &eval_metrics
+      - name: prec_at_5
+        class: prec_at_k
+        params:
+          k: 5
+      - name: prec_at_8
+        class: prec_at_k
+        params:
+          k: 8
+      - name: macro_f1
+      - name: micro_f1
+      - name: macro_auc
+      - name: micro_auc
+    graph:
+      writer:
+        name: tensorboard
+        params:
+          log_dir: *output_dir
+      train:
+        interval: 100
+        interval_unit: step
+        metric:
+          - name: loss
+      val:
+        interval: 1
+        interval_unit: epoch
+        metric:
+          - name: loss
+          - name: prec_at_5
+          - name: prec_at_8
+          - name: macro_f1
+          - name: micro_f1
+          - name: macro_auc
+          - name: micro_auc
+    seed: 1
+    use_gpu: true

--- a/configs/dcan/mimic3_50.yml
+++ b/configs/dcan/mimic3_50.yml
@@ -60,7 +60,8 @@ trainer:
       drop_last: true
     loss:
       name: BinaryCrossEntropyWithLabelSmoothingLoss
-      params: null
+      params:
+        alpha: 0.1
     optimizer:
       name: adam
       params:

--- a/configs/dcan/mimic3_50_old.yml
+++ b/configs/dcan/mimic3_50_old.yml
@@ -1,0 +1,125 @@
+paths:
+  mimic_dir: &mimic_dir datasets/mimic3/csv
+  static_dir: &static_dir datasets/mimic3/static
+  dataset_dir: &dataset_dir datasets/mimic3_50_old
+  word2vec_dir: &word2vec_dir datasets/mimic3_50_old/word2vec
+  output_dir: &output_dir results/CAML_mimic3_50_old
+
+dataset:
+  name: base_dataset
+  data_common: &data_common
+    column_names:
+      hadm_id: "HADM_ID"
+      clinical_note: "TEXT"
+      labels: "LABELS"
+    word2vec_dir: *word2vec_dir
+    pad_token: "<pad>"
+    unk_token: "<unk>"
+    dataset_dir: *dataset_dir
+    label_file: labels.json
+  params:
+    train:
+      <<: *data_common
+      data_file: train.json
+    val:
+      <<: *data_common
+      data_file: val.json
+    test:
+      <<: *data_common
+      data_file: test.json
+
+model:
+  name: dcan
+  params:
+    num_classes: 50
+    word_representation_layer:
+      params:
+        init_params:
+          embed_dir: *word2vec_dir
+          dropout: 0.2
+        freeze_layer: true
+    add_emb_size_to_channel_sizes: true
+    conv_channel_sizes: [[600, 600], [600, 600, 600]]
+    kernel_sizes: [[2, 2], [2, 2]]
+    strides: [[1, 1], [1, 1]]
+    dilations: [[1, 1], [1, 1]]                 # 2^(temporal_conv_net_level)
+    paddings: [[1, 1], [1, 1]]                  # (kernel_size - 1) * dilation_size
+    dropouts: [[0.2, 0.2], [0.2, 0.2]]
+    weight_norm: true
+    projection_size: 300
+    activation: "relu"
+
+trainer:
+  name: base_trainer
+  params:
+    output_dir: *output_dir
+    data_loader:
+      batch_size: 16
+      num_workers: 4
+      shuffle: false
+      drop_last: true
+    loss:
+      name: BinaryCrossEntropyLoss
+      params: null
+    optimizer:
+      name: adam
+      params:
+        lr: 0.0001
+        weight_decay: 0.0
+    max_epochs: 200
+    lr_scheduler: null
+    stopping_criterion:
+      metric:
+        name: prec_at_8
+      desired: max
+      patience: 10
+    checkpoint_saver:
+      name: base_saver
+      params:
+        checkpoint_dir: *output_dir
+        interval: 1
+        max_to_keep: 5
+        ckpt_fname_format: "ckpt-{}.pth"
+        best_fname_format: "best-{}.pth"
+        metric:
+          name: prec_at_8
+          class: prec_at_k
+          params:
+            k: 8
+        desired: max
+    eval_metrics: &eval_metrics
+      - name: prec_at_5
+        class: prec_at_k
+        params:
+          k: 5
+      - name: prec_at_8
+        class: prec_at_k
+        params:
+          k: 8
+      - name: macro_f1
+      - name: micro_f1
+      - name: macro_auc
+      - name: micro_auc
+    graph:
+      writer:
+        name: tensorboard
+        params:
+          log_dir: *output_dir
+      train:
+        interval: 100
+        interval_unit: step
+        metric:
+          - name: loss
+      val:
+        interval: 1
+        interval_unit: epoch
+        metric:
+          - name: loss
+          - name: prec_at_5
+          - name: prec_at_8
+          - name: macro_f1
+          - name: micro_f1
+          - name: macro_auc
+          - name: micro_auc
+    seed: 1
+    use_gpu: true

--- a/configs/dcan/mimic3_50_old.yml
+++ b/configs/dcan/mimic3_50_old.yml
@@ -3,7 +3,7 @@ paths:
   static_dir: &static_dir datasets/mimic3/static
   dataset_dir: &dataset_dir datasets/mimic3_50_old
   word2vec_dir: &word2vec_dir datasets/mimic3_50_old/word2vec
-  output_dir: &output_dir results/CAML_mimic3_50_old
+  output_dir: &output_dir results/dcan_mimic3_50_old
 
 dataset:
   name: base_dataset

--- a/configs/dcan/mimic3_50_old.yml
+++ b/configs/dcan/mimic3_50_old.yml
@@ -59,7 +59,7 @@ trainer:
       shuffle: false
       drop_last: true
     loss:
-      name: BinaryCrossEntropyLoss
+      name: BinaryCrossEntropyWithLabelSmoothingLoss
       params: null
     optimizer:
       name: adam

--- a/configs/dcan/mimic3_50_old.yml
+++ b/configs/dcan/mimic3_50_old.yml
@@ -39,12 +39,12 @@ model:
           dropout: 0.2
         freeze_layer: true
     add_emb_size_to_channel_sizes: true
-    conv_channel_sizes: [[600, 600]]
-    kernel_sizes: [[2, 2]]
-    strides: [[1, 1]]
-    dilations: [[1, 1]]                         # 2^(temporal_conv_net_level)
-    paddings: [[1, 1]]                          # (kernel_size - 1) * dilation_size
-    dropouts: [[0.2, 0.2]]
+    conv_channel_sizes: [[600, 600], [600, 600, 600]]
+    kernel_sizes: [[2, 2], [2, 2]]
+    strides: [[1, 1], [1, 1]]
+    dilations: [[1, 1], [2, 2]]                 # 2^(temporal_conv_net_level)
+    paddings: [[1, 1], [2, 2]]                  # (kernel_size - 1) * dilation_size
+    dropouts: [[0.2, 0.2], [0.2, 0.2]]
     weight_norm: true
     projection_size: 300
     activation: "relu"

--- a/configs/dcan/mimic3_50_old.yml
+++ b/configs/dcan/mimic3_50_old.yml
@@ -39,12 +39,12 @@ model:
           dropout: 0.2
         freeze_layer: true
     add_emb_size_to_channel_sizes: true
-    conv_channel_sizes: [[600, 600], [600, 600, 600]]
-    kernel_sizes: [[2, 2], [2, 2]]
-    strides: [[1, 1], [1, 1]]
-    dilations: [[1, 1], [1, 1]]                 # 2^(temporal_conv_net_level)
-    paddings: [[1, 1], [1, 1]]                  # (kernel_size - 1) * dilation_size
-    dropouts: [[0.2, 0.2], [0.2, 0.2]]
+    conv_channel_sizes: [[600, 600]]
+    kernel_sizes: [[2, 2]]
+    strides: [[1, 1]]
+    dilations: [[1, 1]]                         # 2^(temporal_conv_net_level)
+    paddings: [[1, 1]]                          # (kernel_size - 1) * dilation_size
+    dropouts: [[0.2, 0.2]]
     weight_norm: true
     projection_size: 300
     activation: "relu"

--- a/configs/dcan/mimic3_50_old.yml
+++ b/configs/dcan/mimic3_50_old.yml
@@ -67,7 +67,7 @@ trainer:
       params:
         lr: 0.0001
         weight_decay: 0.0
-    max_epochs: 200
+    max_epochs: 23
     lr_scheduler: null
     stopping_criterion:
       metric:

--- a/configs/dcan/mimic3_50_old.yml
+++ b/configs/dcan/mimic3_50_old.yml
@@ -60,7 +60,8 @@ trainer:
       drop_last: true
     loss:
       name: BinaryCrossEntropyWithLabelSmoothingLoss
-      params: null
+      params:
+        alpha: 0.1
     optimizer:
       name: adam
       params:

--- a/configs/dcan/mimic3_50_old.yml
+++ b/configs/dcan/mimic3_50_old.yml
@@ -17,6 +17,7 @@ dataset:
     unk_token: "<unk>"
     dataset_dir: *dataset_dir
     label_file: labels.json
+    max_length: 2500
   params:
     train:
       <<: *data_common
@@ -39,12 +40,12 @@ model:
           dropout: 0.2
         freeze_layer: true
     add_emb_size_to_channel_sizes: true
-    conv_channel_sizes: [[600, 600], [600, 600, 600]]
-    kernel_sizes: [[2, 2], [2, 2]]
-    strides: [[1, 1], [1, 1]]
-    dilations: [[1, 1], [2, 2]]                 # 2^(temporal_conv_net_level)
-    paddings: [[1, 1], [2, 2]]                  # (kernel_size - 1) * dilation_size
-    dropouts: [[0.2, 0.2], [0.2, 0.2]]
+    conv_channel_sizes: [[600, 600], [600, 600, 600], [600, 600, 600]]
+    kernel_sizes: [[2, 2], [2, 2], [2, 2]]
+    strides: [[1, 1], [1, 1], [1, 1]]
+    dilations: [[1, 1], [2, 2], [4, 4]]                 # 2^(temporal_conv_net_level)
+    paddings: [[1, 1], [2, 2], [4, 4]]                  # (kernel_size - 1) * dilation_size
+    dropouts: [[0.2, 0.2], [0.2, 0.2], [0.2, 0.2]]
     weight_norm: true
     projection_size: 300
     activation: "relu"
@@ -67,7 +68,7 @@ trainer:
       params:
         lr: 0.0001
         weight_decay: 0.0
-    max_epochs: 23
+    max_epochs: 150
     lr_scheduler: null
     stopping_criterion:
       metric:

--- a/configs/dcan/mimic3_full.yml
+++ b/configs/dcan/mimic3_full.yml
@@ -59,7 +59,7 @@ trainer:
       shuffle: false
       drop_last: true
     loss:
-      name: BinaryCrossEntropyLoss
+      name: BinaryCrossEntropyWithLabelSmoothingLoss
       params: null
     optimizer:
       name: adam

--- a/configs/dcan/mimic3_full.yml
+++ b/configs/dcan/mimic3_full.yml
@@ -1,9 +1,9 @@
 paths:
   mimic_dir: &mimic_dir datasets/mimic3/csv
   static_dir: &static_dir datasets/mimic3/static
-  dataset_dir: &dataset_dir datasets/mimic3_50
-  word2vec_dir: &word2vec_dir datasets/mimic3_50/word2vec
-  output_dir: &output_dir results/CAML_mimic3_50
+  dataset_dir: &dataset_dir datasets/mimic3_full
+  word2vec_dir: &word2vec_dir datasets/mimic3_full/word2vec
+  output_dir: &output_dir results/CAML_mimic3_full
 
 dataset:
   name: base_dataset
@@ -31,10 +31,7 @@ dataset:
 model:
   name: dcan
   params:
-    dataset_dir: *dataset_dir
-    mimic_dir: *mimic_dir
-    static_dir: *static_dir
-    num_classes: 50
+    num_classes: 8930
     word_representation_layer:
       params:
         init_params:
@@ -51,8 +48,6 @@ model:
     weight_norm: true
     projection_size: 300
     activation: "relu"
-    pad_token: "<pad>"
-    unk_token: "<unk>"
 
 trainer:
   name: base_trainer
@@ -126,5 +121,5 @@ trainer:
           - name: micro_f1
           - name: macro_auc
           - name: micro_auc
-    seed: 1337
+    seed: 1
     use_gpu: true

--- a/configs/dcan/mimic3_full.yml
+++ b/configs/dcan/mimic3_full.yml
@@ -17,6 +17,7 @@ dataset:
     unk_token: "<unk>"
     dataset_dir: *dataset_dir
     label_file: labels.json
+    max_length: 2500
   params:
     train:
       <<: *data_common
@@ -39,12 +40,12 @@ model:
           dropout: 0.2
         freeze_layer: true
     add_emb_size_to_channel_sizes: true
-    conv_channel_sizes: [[600, 600], [600, 600, 600]]
-    kernel_sizes: [[2, 2], [2, 2]]
-    strides: [[1, 1], [1, 1]]
-    dilations: [[1, 1], [2, 2]]                 # 2^(temporal_conv_net_level)
-    paddings: [[1, 1], [2, 2]]                  # (kernel_size - 1) * dilation_size
-    dropouts: [[0.2, 0.2], [0.2, 0.2]]
+    conv_channel_sizes: [[600, 600], [600, 600, 600], [600, 600, 600]]
+    kernel_sizes: [[2, 2], [2, 2], [2, 2]]
+    strides: [[1, 1], [1, 1], [1, 1]]
+    dilations: [[1, 1], [2, 2], [4, 4]]                 # 2^(temporal_conv_net_level)
+    paddings: [[1, 1], [2, 2], [4, 4]]                  # (kernel_size - 1) * dilation_size
+    dropouts: [[0.2, 0.2], [0.2, 0.2], [0.2, 0.2]]
     weight_norm: true
     projection_size: 300
     activation: "relu"
@@ -67,7 +68,7 @@ trainer:
       params:
         lr: 0.0001
         weight_decay: 0.0
-    max_epochs: 23
+    max_epochs: 150
     lr_scheduler: null
     stopping_criterion:
       metric:
@@ -89,14 +90,14 @@ trainer:
             k: 8
         desired: max
     eval_metrics: &eval_metrics
-      - name: prec_at_5
-        class: prec_at_k
-        params:
-          k: 5
       - name: prec_at_8
         class: prec_at_k
         params:
           k: 8
+      - name: prec_at_15
+        class: prec_at_k
+        params:
+          k: 15
       - name: macro_f1
       - name: micro_f1
       - name: macro_auc
@@ -116,8 +117,8 @@ trainer:
         interval_unit: epoch
         metric:
           - name: loss
-          - name: prec_at_5
           - name: prec_at_8
+          - name: prec_at_15
           - name: macro_f1
           - name: micro_f1
           - name: macro_auc

--- a/configs/dcan/mimic3_full.yml
+++ b/configs/dcan/mimic3_full.yml
@@ -39,12 +39,12 @@ model:
           dropout: 0.2
         freeze_layer: true
     add_emb_size_to_channel_sizes: true
-    conv_channel_sizes: [[600, 600]]
-    kernel_sizes: [[2, 2]]
-    strides: [[1, 1]]
-    dilations: [[1, 1]]                         # 2^(temporal_conv_net_level)
-    paddings: [[1, 1]]                          # (kernel_size - 1) * dilation_size
-    dropouts: [[0.2, 0.2]]
+    conv_channel_sizes: [[600, 600], [600, 600, 600]]
+    kernel_sizes: [[2, 2], [2, 2]]
+    strides: [[1, 1], [1, 1]]
+    dilations: [[1, 1], [2, 2]]                 # 2^(temporal_conv_net_level)
+    paddings: [[1, 1], [2, 2]]                  # (kernel_size - 1) * dilation_size
+    dropouts: [[0.2, 0.2], [0.2, 0.2]]
     weight_norm: true
     projection_size: 300
     activation: "relu"

--- a/configs/dcan/mimic3_full.yml
+++ b/configs/dcan/mimic3_full.yml
@@ -39,12 +39,12 @@ model:
           dropout: 0.2
         freeze_layer: true
     add_emb_size_to_channel_sizes: true
-    conv_channel_sizes: [[600, 600], [600, 600, 600]]
-    kernel_sizes: [[2, 2], [2, 2]]
-    strides: [[1, 1], [1, 1]]
-    dilations: [[1, 1], [1, 1]]                 # 2^(temporal_conv_net_level)
-    paddings: [[1, 1], [1, 1]]                  # (kernel_size - 1) * dilation_size
-    dropouts: [[0.2, 0.2], [0.2, 0.2]]
+    conv_channel_sizes: [[600, 600]]
+    kernel_sizes: [[2, 2]]
+    strides: [[1, 1]]
+    dilations: [[1, 1]]                         # 2^(temporal_conv_net_level)
+    paddings: [[1, 1]]                          # (kernel_size - 1) * dilation_size
+    dropouts: [[0.2, 0.2]]
     weight_norm: true
     projection_size: 300
     activation: "relu"

--- a/configs/dcan/mimic3_full.yml
+++ b/configs/dcan/mimic3_full.yml
@@ -67,7 +67,7 @@ trainer:
       params:
         lr: 0.0001
         weight_decay: 0.0
-    max_epochs: 200
+    max_epochs: 23
     lr_scheduler: null
     stopping_criterion:
       metric:

--- a/configs/dcan/mimic3_full.yml
+++ b/configs/dcan/mimic3_full.yml
@@ -3,7 +3,7 @@ paths:
   static_dir: &static_dir datasets/mimic3/static
   dataset_dir: &dataset_dir datasets/mimic3_full
   word2vec_dir: &word2vec_dir datasets/mimic3_full/word2vec
-  output_dir: &output_dir results/CAML_mimic3_full
+  output_dir: &output_dir results/dcan_mimic3_full
 
 dataset:
   name: base_dataset

--- a/configs/dcan/mimic3_full.yml
+++ b/configs/dcan/mimic3_full.yml
@@ -60,7 +60,8 @@ trainer:
       drop_last: true
     loss:
       name: BinaryCrossEntropyWithLabelSmoothingLoss
-      params: null
+      params:
+        alpha: 0.1
     optimizer:
       name: adam
       params:

--- a/configs/dcan/mimic3_full_old.yml
+++ b/configs/dcan/mimic3_full_old.yml
@@ -1,9 +1,9 @@
 paths:
   mimic_dir: &mimic_dir datasets/mimic3/csv
   static_dir: &static_dir datasets/mimic3/static
-  dataset_dir: &dataset_dir datasets/mimic3_50
-  word2vec_dir: &word2vec_dir datasets/mimic3_50/word2vec
-  output_dir: &output_dir results/dcan_mimic3_50
+  dataset_dir: &dataset_dir datasets/mimic3_full_old
+  word2vec_dir: &word2vec_dir datasets/mimic3_full_old/word2vec
+  output_dir: &output_dir results/dcan_mimic3_full_old
 
 dataset:
   name: base_dataset
@@ -32,7 +32,7 @@ dataset:
 model:
   name: dcan
   params:
-    num_classes: 50
+    num_classes: 8922
     word_representation_layer:
       params:
         init_params:
@@ -90,14 +90,14 @@ trainer:
             k: 8
         desired: max
     eval_metrics: &eval_metrics
-      - name: prec_at_5
-        class: prec_at_k
-        params:
-          k: 5
       - name: prec_at_8
         class: prec_at_k
         params:
           k: 8
+      - name: prec_at_15
+        class: prec_at_k
+        params:
+          k: 15
       - name: macro_f1
       - name: micro_f1
       - name: macro_auc
@@ -117,8 +117,8 @@ trainer:
         interval_unit: epoch
         metric:
           - name: loss
-          - name: prec_at_5
           - name: prec_at_8
+          - name: prec_at_15
           - name: macro_f1
           - name: micro_f1
           - name: macro_auc

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,2 +1,3 @@
 from src.models.caml import ConvAttnPool as CAML
 from src.models.caml import VanillaConv as CNN
+from src.models.dcan import DCAN

--- a/src/models/dcan.py
+++ b/src/models/dcan.py
@@ -8,6 +8,9 @@ from src.modules.layers.label_wise_attn import LabelWiseAttn
 from src.modules.layers.temporal_conv_net import TemporalConvNet
 from src.modules.layers.word_embedding_layer import WordEmbeddingLayer
 from src.utils.mapper import ConfigMapper
+from src.utils.text_loggers import get_logger
+
+logger = get_logger(__name__)
 
 
 @ConfigMapper.map("models", "dcan")
@@ -69,6 +72,11 @@ class DCAN(nn.Module):
 
     def __init__(self, config):
         super(DCAN, self).__init__()
+        logger.info(f"Initialising {self.__class__.__name__}")
+        logger.debug(
+            f"Initialising {self.__class__.__name__} with " f"config: {config}"
+        )
+
         self.config = config
 
         self.word_embedding_layer = WordEmbeddingLayer(

--- a/src/models/dcan.py
+++ b/src/models/dcan.py
@@ -1,0 +1,78 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.init import xavier_uniform_
+
+from src.modules.layers.label_wise_attn import LabelWiseAttn
+from src.modules.layers.temporal_conv_net import TemporalConvNet
+from src.modules.layers.word_embedding_layer import WordEmbeddingLayer
+from src.utils.mapper import ConfigMapper
+
+
+@ConfigMapper.map("models", "dcan")
+class DCAN(nn.Module):
+    def __init__(self, config):
+        super(DCAN, self).__init__()
+        self.config = config
+
+        self.word_embedding_layer = WordEmbeddingLayer(
+            **config.word_representation_layer.params.init_params.as_dict()
+        )
+        if config.word_representation_layer.params.freeze_layer:
+            self.freeze_embedding_layer(
+                self.word_embedding_layer.embed.parameters()
+            )
+
+        conv_channel_sizes = config.conv_channel_sizes
+        if config.add_emb_size_to_channel_sizes:
+            for dim_1 in conv_channel_sizes:
+                dim_1 = self.word_embedding_layer.embedding_size + dim_1
+
+        self.temporal_conv_net = TemporalConvNet(
+            conv_channel_sizes_=conv_channel_sizes,
+            kernel_sizes_=config.kernel_sizes,
+            strides_=config.strides,
+            paddings_=config.paddings,
+            dilations_=config.dilations,
+            dropouts_=config.dropouts,
+            weight_norm=config.weight_norm,
+            activation=config.activation,
+        )
+
+        self.linear_layer = nn.Linear(
+            conv_channel_sizes[-1][-1], config.projection_size
+        )
+        self.activation = ConfigMapper.get_object(
+            "activations", config.activation
+        )
+
+        self.output_layer = OutputLayer(
+            config.projection_size, config.num_classes
+        )
+
+        xavier_uniform_(self.linear_layer.weight)
+
+    def forward(self, data):
+        x = self.word_embedding_layer(data)
+        hid_seq = self.temporal_conv_net(x.transpose(1, 2)).transpose(1, 2)
+        hid_seq = self.activation(self.lin(hid_seq))
+        logits = self.output_layer(hid_seq)
+        return logits
+
+    def freeze_embedding_layer(self):
+        for param in self.word_embedding_layer.embed.parameters():
+            param.requires_grad = False
+
+
+class OutputLayer(nn.Module):
+    def __init__(self, input_size, num_classes):
+        super(OutputLayer, self).__init__()
+        self.label_wise_attn = LabelWiseAttn(self, input_size, num_classes)
+
+        self.final = nn.Linear(input_size, num_classes)
+        xavier_uniform_(self.final.weight)
+
+    def forward(self, x):
+        m = self.label_wise_attn(x)
+        logits = self.final.weight.mul(m).sum(dim=2).add(self.final.bias)
+        return logits

--- a/src/models/dcan.py
+++ b/src/models/dcan.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.init import xavier_uniform_
 
+from src.modules.activations import *
 from src.modules.layers.label_wise_attn import LabelWiseAttn
 from src.modules.layers.temporal_conv_net import TemporalConvNet
 from src.modules.layers.word_embedding_layer import WordEmbeddingLayer
@@ -11,6 +12,61 @@ from src.utils.mapper import ConfigMapper
 
 @ConfigMapper.map("models", "dcan")
 class DCAN(nn.Module):
+    """
+    This class is used to create the DCAN model.
+    References:
+        Paper: https://aclanthology.org/2020.clinicalnlp-1.8/
+        GitHub Repository: https://github.com/shaoxiongji/DCAN
+    For the parameters related to convolutional layers, please see this:
+    https://pytorch.org/docs/stable/generated/torch.nn.Conv1d.html.
+    Args:
+        num_classes (int): Number of classes (ICD codes).
+        conv_channel_sizes (list): List of lists of integers. Each list
+                                   represents the channel sizes of convolutional
+                                   layers in a `TemporalBlock`. So, for example,
+                                   if the list is [[100, 600, 600],
+                                                   [600, 600, 600]].
+                                   the `TemporalConvNet` layer will have 2
+                                   `TemporalBlock`s, each temporal block have
+                                   2 convolutional layers:
+                                   Conv(100, 600), Conv(600, 600) for the first
+                                   one, and Conv(600, 600), Conv(600, 600). If
+                                   the `add_emb_size_to_channel_sizes`, we don't
+                                   have to pass the input channel size. So, in
+                                   the above case, we can just pass
+                                   [[600, 600], [600, 600, 600]].
+        add_emb_size_to_channel_sizes (bool): If True, you need not specify
+                                              the input channel size. Please
+                                              see the description of
+                                              `conv_channel_sizes`.
+        kernel_sizes (list): List of list of integers (same format as
+                             `conv_channel_sizes`). Each integer represents the
+                             kernel size/filter size of the respective
+                             convolutional layer in `TemporalBlock` layer.
+        strides (list): List of list of integers (same format as
+                        `conv_channel_sizes`). Each integer represents the
+                        stride of the respective convolutional layer in
+                        `TemporalBlock` layer.
+        paddings (list): List of list of integers (same format as
+                         `conv_channel_sizes`). Each integer represents the
+                         padding of the respective convolutional layer in
+                         `TemporalBlock` layer. in DCAN, this value is set to
+                         "(kernel_size - 1) * dilation_size".
+        dilations (list): List of list of integers (same format as
+                          `conv_channel_sizes`). Each integer represents the
+                          dilation size of the respective convolutional layer
+                          `TemporalBlock` layer.` In DCAN, this value is
+                          "2^(temporal_block_level)".
+        dropouts (list): List of list of floats (same format as
+                         `conv_channel_sizes`). Each float represents the
+                         dropout probability of the respective convolutional
+                         `TemporalBlock` layer.
+        weight_norm (bool): If True, apply weight normalization to the
+                            convolutional layers.
+        activation (str): Activation function to use. Should be one of "relu",
+                          "elu", "leaky_relu".
+    """
+
     def __init__(self, config):
         super(DCAN, self).__init__()
         self.config = config
@@ -19,14 +75,13 @@ class DCAN(nn.Module):
             **config.word_representation_layer.params.init_params.as_dict()
         )
         if config.word_representation_layer.params.freeze_layer:
-            self.freeze_embedding_layer(
-                self.word_embedding_layer.embed.parameters()
-            )
+            self.freeze_layer(self.word_embedding_layer.embed)
 
         conv_channel_sizes = config.conv_channel_sizes
         if config.add_emb_size_to_channel_sizes:
-            for dim_1 in conv_channel_sizes:
-                dim_1 = self.word_embedding_layer.embedding_size + dim_1
+            conv_channel_sizes[0] = [
+                self.word_embedding_layer.embedding_size
+            ] + conv_channel_sizes[0]
 
         self.temporal_conv_net = TemporalConvNet(
             conv_channel_sizes_=conv_channel_sizes,
@@ -44,7 +99,7 @@ class DCAN(nn.Module):
         )
         self.activation = ConfigMapper.get_object(
             "activations", config.activation
-        )
+        )()
 
         self.output_layer = OutputLayer(
             config.projection_size, config.num_classes
@@ -55,19 +110,19 @@ class DCAN(nn.Module):
     def forward(self, data):
         x = self.word_embedding_layer(data)
         hid_seq = self.temporal_conv_net(x.transpose(1, 2)).transpose(1, 2)
-        hid_seq = self.activation(self.lin(hid_seq))
+        hid_seq = self.activation(self.linear_layer(hid_seq))
         logits = self.output_layer(hid_seq)
         return logits
 
-    def freeze_embedding_layer(self):
-        for param in self.word_embedding_layer.embed.parameters():
+    def freeze_layer(self, layer):
+        for param in layer.parameters():
             param.requires_grad = False
 
 
 class OutputLayer(nn.Module):
     def __init__(self, input_size, num_classes):
         super(OutputLayer, self).__init__()
-        self.label_wise_attn = LabelWiseAttn(self, input_size, num_classes)
+        self.label_wise_attn = LabelWiseAttn(input_size, num_classes)
 
         self.final = nn.Linear(input_size, num_classes)
         xavier_uniform_(self.final.weight)

--- a/src/modules/layers/label_wise_attn.py
+++ b/src/modules/layers/label_wise_attn.py
@@ -4,6 +4,10 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.init import xavier_uniform_
 
+from src.utils.text_loggers import get_logger
+
+logger = get_logger(__name__)
+
 
 class LabelWiseAttn(nn.Module):
     """
@@ -21,6 +25,11 @@ class LabelWiseAttn(nn.Module):
 
     def __init__(self, input_size, num_classes):
         super(LabelWiseAttn, self).__init__()
+        logger.debug(
+            f"Initialising {self.__class__.__name__} with "
+            f"input size = {input_size}, num_classes = {num_classes}"
+        )
+
         self.U = nn.Linear(input_size, num_classes)
         xavier_uniform_(self.U.weight)
 

--- a/src/modules/layers/label_wise_attn.py
+++ b/src/modules/layers/label_wise_attn.py
@@ -1,10 +1,26 @@
+# flake8: noqa
+
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.init import xavier_uniform_
 
 
 class LabelWiseAttn(nn.Module):
+    """
+    A Label-wise Attention layer (as implemented in CAML, DCAN, etc.).
+    References:
+        Papers: https://arxiv.org/abs/1802.05695 (Section 2.2)
+        Repository: https://github.com/jamesmullenbach/caml-mimic/blob/master/learn/models.py#L184
+
+    Args:
+        input_size (int): The size of the input, i.e., the number of channels
+                          if the output is from a convolutional layer/embedding
+                          size if the output is from a fully connected layer.
+        num_classes (int): The number of classes.
+    """
+
     def __init__(self, input_size, num_classes):
+        super(LabelWiseAttn, self).__init__()
         self.U = nn.Linear(input_size, num_classes)
         xavier_uniform_(self.U.weight)
 

--- a/src/modules/layers/label_wise_attn.py
+++ b/src/modules/layers/label_wise_attn.py
@@ -1,0 +1,15 @@
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.init import xavier_uniform_
+
+
+class LabelWiseAttn(nn.Module):
+    def __init__(self, input_size, num_classes):
+        self.U = nn.Linear(input_size, num_classes)
+        xavier_uniform_(self.U.weight)
+
+    def forward(self, x):
+        att = self.U.weight.matmul(x.transpose(1, 2))  # [bs, Y, seq_len]
+        alpha = F.softmax(att, dim=2)
+        m = alpha.matmul(x)  # [bs, Y, dim]
+        return m

--- a/src/modules/layers/temporal_block.py
+++ b/src/modules/layers/temporal_block.py
@@ -6,6 +6,9 @@ from torch.nn.utils import weight_norm as weight_norm_
 
 from src.modules.activations import *
 from src.utils.mapper import ConfigMapper
+from src.utils.text_loggers import get_logger
+
+logger = get_logger(__name__)
 
 
 class Chomp1d(nn.Module):
@@ -56,6 +59,15 @@ class ConvTemporalSubBlock(nn.Module):
         activation="relu",
     ):
         super(ConvTemporalSubBlock, self).__init__()
+        logger.debug(
+            f"Initialising {self.__class__.__name__} with "
+            f"in_channels = {in_channels}, out_channels = "
+            f"{out_channels}, kernel_size = {kernel_size}, "
+            f"stride = {stride}, padding = {padding}, "
+            f"dilation = {dilation}, dropout = {dropout}, "
+            f"weight_norm = {weight_norm}, activation = {activation}"
+        )
+
         self.conv_layer = nn.Conv1d(
             in_channels=in_channels,
             out_channels=out_channels,

--- a/src/modules/layers/temporal_block.py
+++ b/src/modules/layers/temporal_block.py
@@ -1,0 +1,126 @@
+import torch.nn as nn
+from torch.nn.init import xavier_uniform_
+from torch.nn.utils import weight_norm as weight_norm_
+
+from src.utils.mapper import ConfigMapper
+
+
+class Chomp1d(nn.Module):
+    def __init__(self, chomp_size):
+        super(Chomp1d, self).__init__()
+        self.chomp_size = chomp_size
+
+    def forward(self, x):
+        return x[:, :, : -self.chomp_size].contiguous()
+
+
+class ConvTemporalSubBlock(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        dropout=0.2,
+        weight_norm=True,
+        activation="relu",
+    ):
+        self.conv_layer = nn.Conv1d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+        )
+        if weight_norm:
+            self.conv_layer = weight_norm_(self.conv_layer)
+        self.chomp1d = Chomp1d(padding)
+        self.activation = ConfigMapper.get_object("activations", activation)()
+        self.dropout = nn.Dropout(dropout)
+
+        self.__init_weights__()
+
+    def __init_weights__(self):
+        xavier_uniform_(self.conv_layer.weight)
+
+    def forward(self, x):
+        x = self.conv_layer(x)
+        x = self.chomp1d(x)
+        x = self.activation(x)
+        x = self.dropout(x)
+        return x
+
+
+class TemporalBlock(nn.Module):
+    def __init__(
+        self,
+        conv_channel_sizes,
+        kernel_sizes,
+        strides,
+        paddings,
+        dilations,
+        dropouts,
+        weight_norm=True,
+        activation="relu",
+    ):
+        super(TemporalBlock, self).__init__()
+        conv_channel_size_pairs = list(
+            zip(conv_channel_sizes[:-1], conv_channel_sizes[1:])
+        )
+
+        self.conv_temporal_sub_blocks = nn.ModuleList(
+            [
+                ConvTemporalSubBlock(
+                    in_channels=conv_channel_size_pair[0],
+                    out_channels=conv_channel_size_pair[1],
+                    kernel_size=kernel_size,
+                    stride=stride,
+                    padding=padding,
+                    dilation=dilation,
+                    dropout=dropout,
+                    weight_norm=weight_norm,
+                    activation=activation,
+                )
+                for (
+                    conv_channel_size_pair,
+                    kernel_size,
+                    stride,
+                    padding,
+                    dilation,
+                    dropout,
+                ) in zip(
+                    conv_channel_size_pairs,
+                    kernel_sizes,
+                    strides,
+                    paddings,
+                    dilations,
+                    dropouts,
+                )
+            ]
+        )
+
+        self.downsample = (
+            nn.Conv1d(conv_channel_sizes[0], conv_channel_sizes[-1], 1)
+            if conv_channel_sizes[0] != conv_channel_sizes[-1]
+            else None
+        )
+        self.output_activation = ConfigMapper.get_object(
+            "activations", activation
+        )()
+
+        self.init_weights()
+
+    def init_weights(self):
+        if self.downsample is not None:
+            xavier_uniform_(self.downsample.weight)
+
+    def forward(self, x):
+        conv_layer_output = self.conv_temporal_sub_blocks[0](x)
+        if len(self.conv_temporal_sub_blocks) > 0:
+            for conv_temporal_sub_block in self.conv_temporal_sub_blocks[1:]:
+                conv_layer_output = conv_temporal_sub_block(conv_layer_output)
+        res = x if self.downsample is None else self.downsample(x)
+        return self.output_activation(conv_layer_output + res)

--- a/src/modules/layers/temporal_conv_net.py
+++ b/src/modules/layers/temporal_conv_net.py
@@ -15,41 +15,41 @@ class TemporalConvNet(nn.Module):
 
     Args:
         conv_channel_sizes_ (list): List of lists of integers. Each list
-                                   represents the channel sizes of convolutional
-                                   layers in a `TemporalBlock`. So, for example,
-                                   if the list is [[100, 600, 600],
-                                                   [600, 600, 600]].
-                                   the `TemporalConvNet` layer will have 2
-                                   `TemporalBlock`s, each temporal block have
-                                   2 convolutional layers:
-                                   Conv(100, 600), Conv(600, 600) for the first
-                                   one, and Conv(600, 600), Conv(600, 600). If
-                                   the `add_emb_size_to_channel_sizes`, we don't
-                                   have to pass the input channel size. So, in
-                                   the above case, we can just pass
-                                   [[600, 600], [600, 600, 600]].
+                                    represents the channel sizes of convolutional
+                                    layers in a `TemporalBlock`. So, for
+                                    example, if the list is [[100, 600, 600],
+                                                             [600, 600, 600]].
+                                    the `TemporalConvNet` layer will have 2
+                                    `TemporalBlock`s, each temporal block have
+                                    2 convolutional layers:
+                                    Conv(100, 600), Conv(600, 600) for the first
+                                    one, and Conv(600, 600), Conv(600, 600). If
+                                    the `add_emb_size_to_channel_sizes`, we
+                                    don't have to pass the input channel size.
+                                    So, in the above case, we can just pass
+                                    [[600, 600], [600, 600, 600]].
         kernel_sizes_ (list): List of list of integers (same format as
-                             `conv_channel_sizes`). Each integer represents the
-                             kernel size/filter size of the respective
-                             convolutional layer in `TemporalBlock` layer.
+                              `conv_channel_sizes`). Each integer represents the
+                              kernel size/filter size of the respective
+                              convolutional layer in `TemporalBlock` layer.
         strides_ (list): List of list of integers (same format as
-                        `conv_channel_sizes`). Each integer represents the
-                        stride of the respective convolutional layer in
-                        `TemporalBlock` layer.
-        paddings_ (list): List of list of integers (same format as
                          `conv_channel_sizes`). Each integer represents the
-                         padding of the respective convolutional layer in
-                         `TemporalBlock` layer. in DCAN, this value is set to
-                         "(kernel_size - 1) * dilation_size".
-        dilations_ (list): List of list of integers (same format as
-                          `conv_channel_sizes`). Each integer represents the
-                          dilation size of the respective convolutional layer
-                          `TemporalBlock` layer.` In DCAN, this value is
-                          "2^(temporal_block_level)".
-        dropouts_ (list): List of list of floats (same format as
-                         `conv_channel_sizes`). Each float represents the
-                         dropout probability of the respective convolutional
+                         stride of the respective convolutional layer in
                          `TemporalBlock` layer.
+        paddings_ (list): List of list of integers (same format as
+                          `conv_channel_sizes`). Each integer represents the
+                          padding of the respective convolutional layer in
+                          `TemporalBlock` layer. in DCAN, this value is set to
+                          "(kernel_size - 1) * dilation_size".
+        dilations_ (list): List of list of integers (same format as
+                           `conv_channel_sizes`). Each integer represents the
+                           dilation size of the respective convolutional layer
+                           `TemporalBlock` layer.` In DCAN, this value is
+                           "2^(temporal_block_level)".
+        dropouts_ (list): List of list of floats (same format as
+                          `conv_channel_sizes`). Each float represents the
+                          dropout probability of the respective convolutional
+                          `TemporalBlock` layer.
         weight_norm (bool): If True, apply weight normalization to the
                             convolutional layers.
         activation (str): Activation function to use. DCAN uses "relu".

--- a/src/modules/layers/temporal_conv_net.py
+++ b/src/modules/layers/temporal_conv_net.py
@@ -1,9 +1,60 @@
+# flake8: noqa
+
 import torch.nn as nn
 
+from src.modules.activations import *
 from src.modules.layers.temporal_block import TemporalBlock
 
 
 class TemporalConvNet(nn.Module):
+    """
+    Stack of `TemporalBlock`s. Used in the DCAN model.
+    References:
+        Paper: https://arxiv.org/abs/2009.14578
+        Repository: https://github.com/shaoxiongji/DCAN/blob/master/models.py#L114
+
+    Args:
+        conv_channel_sizes_ (list): List of lists of integers. Each list
+                                   represents the channel sizes of convolutional
+                                   layers in a `TemporalBlock`. So, for example,
+                                   if the list is [[100, 600, 600],
+                                                   [600, 600, 600]].
+                                   the `TemporalConvNet` layer will have 2
+                                   `TemporalBlock`s, each temporal block have
+                                   2 convolutional layers:
+                                   Conv(100, 600), Conv(600, 600) for the first
+                                   one, and Conv(600, 600), Conv(600, 600). If
+                                   the `add_emb_size_to_channel_sizes`, we don't
+                                   have to pass the input channel size. So, in
+                                   the above case, we can just pass
+                                   [[600, 600], [600, 600, 600]].
+        kernel_sizes_ (list): List of list of integers (same format as
+                             `conv_channel_sizes`). Each integer represents the
+                             kernel size/filter size of the respective
+                             convolutional layer in `TemporalBlock` layer.
+        strides_ (list): List of list of integers (same format as
+                        `conv_channel_sizes`). Each integer represents the
+                        stride of the respective convolutional layer in
+                        `TemporalBlock` layer.
+        paddings_ (list): List of list of integers (same format as
+                         `conv_channel_sizes`). Each integer represents the
+                         padding of the respective convolutional layer in
+                         `TemporalBlock` layer. in DCAN, this value is set to
+                         "(kernel_size - 1) * dilation_size".
+        dilations_ (list): List of list of integers (same format as
+                          `conv_channel_sizes`). Each integer represents the
+                          dilation size of the respective convolutional layer
+                          `TemporalBlock` layer.` In DCAN, this value is
+                          "2^(temporal_block_level)".
+        dropouts_ (list): List of list of floats (same format as
+                         `conv_channel_sizes`). Each float represents the
+                         dropout probability of the respective convolutional
+                         `TemporalBlock` layer.
+        weight_norm (bool): If True, apply weight normalization to the
+                            convolutional layers.
+        activation (str): Activation function to use. DCAN uses "relu".
+    """
+
     def __init__(
         self,
         conv_channel_sizes_,

--- a/src/modules/layers/temporal_conv_net.py
+++ b/src/modules/layers/temporal_conv_net.py
@@ -1,0 +1,52 @@
+import torch.nn as nn
+
+from src.modules.layers.temporal_block import TemporalBlock
+
+
+class TemporalConvNet(nn.Module):
+    def __init__(
+        self,
+        conv_channel_sizes_,
+        kernel_sizes_,
+        strides_,
+        paddings_,
+        dilations_,
+        dropouts_,
+        weight_norm=True,
+        activation="relu",
+    ):
+        super(TemporalConvNet, self).__init__()
+        self.temporal_blocks = nn.ModuleList(
+            [
+                TemporalBlock(
+                    conv_channel_sizes=conv_channel_sizes,
+                    kernel_sizes=kernel_sizes,
+                    strides=strides,
+                    paddings=paddings,
+                    dilations=dilations,
+                    dropouts=dropouts,
+                    weight_norm=weight_norm,
+                    activation=activation,
+                )
+                for (
+                    conv_channel_sizes,
+                    kernel_sizes,
+                    strides,
+                    paddings,
+                    dilations,
+                    dropouts,
+                ) in zip(
+                    conv_channel_sizes_,
+                    kernel_sizes_,
+                    strides_,
+                    paddings_,
+                    dilations_,
+                    dropouts_,
+                )
+            ]
+        )
+
+    def forward(self, x):
+        for temporal_block in self.temporal_blocks:
+            x = temporal_block(x)
+        return x

--- a/src/modules/layers/temporal_conv_net.py
+++ b/src/modules/layers/temporal_conv_net.py
@@ -4,6 +4,9 @@ import torch.nn as nn
 
 from src.modules.activations import *
 from src.modules.layers.temporal_block import TemporalBlock
+from src.utils.text_loggers import get_logger
+
+logger = get_logger(__name__)
 
 
 class TemporalConvNet(nn.Module):
@@ -67,6 +70,15 @@ class TemporalConvNet(nn.Module):
         activation="relu",
     ):
         super(TemporalConvNet, self).__init__()
+        logger.debug(
+            f"Initialising {self.__class__.__name__} with "
+            f"conv_channel_sizes_ = {conv_channel_sizes_}, "
+            f"kernel_sizes_ = {kernel_sizes_}, "
+            f"strides_ = {strides_}, paddings_ = {paddings_}, "
+            f"dilations_ = {dilations_}, dropouts_ = {dropouts_}, "
+            f"weight_norm = {weight_norm}, activation = {activation}"
+        )
+
         self.temporal_blocks = nn.ModuleList(
             [
                 TemporalBlock(

--- a/src/modules/layers/word_embedding_layer.py
+++ b/src/modules/layers/word_embedding_layer.py
@@ -1,0 +1,26 @@
+import torch
+import torch.nn as nn
+
+from src.utils.caml_utils import load_embeddings
+from src.utils.mapper import ConfigMapper
+
+
+class WordEmbeddingLayer(nn.Module):
+    def __init__(self, embed_dir, dropout):
+        super(WordEmbeddingLayer, self).__init__()
+        embedding_cls = ConfigMapper.get_object("embeddings", "word2vec")
+
+        W = torch.Tensor(
+            load_embeddings(embedding_cls.load_emb_matrix(embed_dir))
+        )
+        self.embed = nn.Embedding(W.size()[0], W.size()[1], padding_idx=0)
+        self.embed.weight.data = W.clone()
+
+        self.embedding_size = self.embed.embedding_dim
+
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x):
+        embedding = self.embed(x)
+        x = self.dropout(embedding)
+        return x

--- a/src/modules/layers/word_embedding_layer.py
+++ b/src/modules/layers/word_embedding_layer.py
@@ -1,18 +1,28 @@
 import torch
 import torch.nn as nn
 
-from src.utils.caml_utils import load_embeddings
 from src.utils.mapper import ConfigMapper
 
 
 class WordEmbeddingLayer(nn.Module):
+    """
+    A Word Embedding Layer. This layer loads a pre-trained word embedding matrix
+    , and copies its weights to an nn.Embedding layer.
+
+    Args:
+        embed_dir (str): A directory containing the pre-trained word embedding
+                         matrix, among other things. Please see
+                         https://github.com/dalgu90/icd-coding-benchmark/blob/main/src/modules/embeddings.py#L17
+                         for more details.
+        dropout (float): The dropout probability.
+    """
+
     def __init__(self, embed_dir, dropout):
         super(WordEmbeddingLayer, self).__init__()
+        # Note: This should be changed, since we won't always use Word2Vec.
         embedding_cls = ConfigMapper.get_object("embeddings", "word2vec")
 
-        W = torch.Tensor(
-            load_embeddings(embedding_cls.load_emb_matrix(embed_dir))
-        )
+        W = torch.Tensor(embedding_cls.load_emb_matrix(embed_dir))
         self.embed = nn.Embedding(W.size()[0], W.size()[1], padding_idx=0)
         self.embed.weight.data = W.clone()
 

--- a/src/modules/layers/word_embedding_layer.py
+++ b/src/modules/layers/word_embedding_layer.py
@@ -2,6 +2,9 @@ import torch
 import torch.nn as nn
 
 from src.utils.mapper import ConfigMapper
+from src.utils.text_loggers import get_logger
+
+logger = get_logger(__name__)
 
 
 class WordEmbeddingLayer(nn.Module):
@@ -19,6 +22,11 @@ class WordEmbeddingLayer(nn.Module):
 
     def __init__(self, embed_dir, dropout):
         super(WordEmbeddingLayer, self).__init__()
+        logger.debug(
+            f"Initialising {self.__class__.__name__} with "
+            f"embed_dir = {embed_dir}, dropout = {dropout}"
+        )
+
         # Note: This should be changed, since we won't always use Word2Vec.
         embedding_cls = ConfigMapper.get_object("embeddings", "word2vec")
 

--- a/src/modules/losses.py
+++ b/src/modules/losses.py
@@ -25,12 +25,14 @@ class BinaryCrossEntropyLoss(BCEWithLogitsLoss):
 class BinaryCrossEntropyWithLabelSmoothingLoss(BCEWithLogitsLoss):
     def __init__(self, config):
         self.config = config
-        super().__init__(**(config.as_dict() if config else {}))
+
+        config_dict = config.as_dict()
+        self.alpha = config_dict.pop("alpha")
+
+        super().__init__(**(config_dict if config else {}))
 
     def forward(self, input, target):
         if target.dtype != torch.float:
             target = target.float()
-        target = target * (
-            1 - self.config.alpha
-        ) + self.config.alpha / target.size(1)
+        target = target * (1 - self.alpha) + self.alpha / target.size(1)
         return super().forward(input=input, target=target)

--- a/src/modules/losses.py
+++ b/src/modules/losses.py
@@ -19,3 +19,18 @@ class BinaryCrossEntropyLoss(BCEWithLogitsLoss):
         if target.dtype != torch.float:
             target = target.float()
         return super().forward(input=input, target=target)
+
+
+@ConfigMapper.map("losses", "BinaryCrossEntropyWithLabelSmoothingLoss")
+class BinaryCrossEntropyWithLabelSmoothingLoss(BCEWithLogitsLoss):
+    def __init__(self, config):
+        self.config = config
+        super().__init__(**(config.as_dict() if config else {}))
+
+    def forward(self, input, target):
+        if target.dtype != torch.float:
+            target = target.float()
+        target = target * (
+            1 - self.config.alpha
+        ) + self.config.alpha / target.size(1)
+        return super().forward(input=input, target=target)


### PR DESCRIPTION
**NOTE: The DCAN [default hyperparams](https://agit.ai/jsx/DCAN/src/branch/master/options.py) don't seem to be the best choice of hyperparameters (since number of levels = 1, which means we don't have Dilated Conv layers of size 2, 4, 8, etc. We have only 1).** I've opened an [issue](https://github.com/shaoxiongji/DCAN/issues/5) on the official DCAN repository.

**NOTE: On further investigation, a 3-level DCAN (our implementation) has 8.9M params (the paper mentions that the model has 8.7M params. So, it's likely that they used a 3-level DCAN.**

To-dos:
- [x] Add layers (`label_wise_attn`, `word_embedding_layer`, `temporal_block`, `temporal_conv_net`)
- [x] Add DCAN model class.
- [x] Check if the model works (ran it for 11% of an epoch).
- [x] Add doc-strings to functions and classes.
- [x] DCAN uses **label smoothing**. I think we will have to write a custom loss class that inherits from PyTorch losses.  
- [x] Train model and verify results.
- [x] Add log statements.
- [x] Change dropout to scalar.

Do later:
- [ ] Add a param, `num_level`. If `num_level` is specified, the user does not have to specify lists for the other model params.
Model Structure:
```
DCAN(
  (word_embedding_layer): WordEmbeddingLayer(
    (embed): Embedding(49800, 100, padding_idx=0)
    (dropout): Dropout(p=0.2, inplace=False)
  )
  (temporal_conv_net): TemporalConvNet(
    (temporal_blocks): ModuleList(
      (0): TemporalBlock(
        (conv_temporal_sub_blocks): ModuleList(
          (0): ConvTemporalSubBlock(
            (conv_layer): Conv1d(100, 600, kernel_size=(2,), stride=(1,), padding=(1,))
            (chomp1d): Chomp1d()
            (activation): ReLU()
            (dropout): Dropout(p=0.2, inplace=False)
          )
          (1): ConvTemporalSubBlock(
            (conv_layer): Conv1d(600, 600, kernel_size=(2,), stride=(1,), padding=(1,))
            (chomp1d): Chomp1d()
            (activation): ReLU()
            (dropout): Dropout(p=0.2, inplace=False)
          )
        )
        (downsample): Conv1d(100, 600, kernel_size=(1,), stride=(1,))
        (output_activation): ReLU()
      )
      (1): TemporalBlock(
        (conv_temporal_sub_blocks): ModuleList(
          (0): ConvTemporalSubBlock(
            (conv_layer): Conv1d(600, 600, kernel_size=(2,), stride=(1,), padding=(1,))
            (chomp1d): Chomp1d()
            (activation): ReLU()
            (dropout): Dropout(p=0.2, inplace=False)
          )
          (1): ConvTemporalSubBlock(
            (conv_layer): Conv1d(600, 600, kernel_size=(2,), stride=(1,), padding=(1,))
            (chomp1d): Chomp1d()
            (activation): ReLU()
            (dropout): Dropout(p=0.2, inplace=False)
          )
        )
        (output_activation): ReLU()
      )
    )
  )
  (linear_layer): Linear(in_features=600, out_features=300, bias=True)
  (activation): ReLU()
  (output_layer): OutputLayer(
    (label_wise_attn): LabelWiseAttn(
      (U): Linear(in_features=300, out_features=50, bias=True)
    )
    (final): Linear(in_features=300, out_features=50, bias=True)
  )
)
```

Results:

MIMIC-III (top-50, ours), with 2 level DCAN:
```
Val @ epoch 46:
INFO — Evaluate on val dataset
INFO —    prec_at_5: 0.678521
INFO —    prec_at_8: 0.549315
INFO —     macro_f1: 0.662994
INFO —     micro_f1: 0.733202
INFO —    macro_auc: 0.933964
INFO —    micro_auc: 0.952682
INFO — Checkpoint saved to ckpt-46.pth
INFO — Checkpoint saved to best-46.pth (prec_at_8: 0.549315)

Val @ epoch 56:
INFO — Evaluate on val dataset
INFO —    prec_at_5: 0.678266
INFO —    prec_at_8: 0.549156
INFO —     macro_f1: 0.663466
INFO —     micro_f1: 0.732965
INFO —    macro_auc: 0.934129
INFO —    micro_auc: 0.952837
INFO — Checkpoint saved to ckpt-56.pth

Test (@ epoch 46):
INFO — Loaded checkpoint from best-46.pth
INFO — Use GPU
INFO — Evaluating on test dataset
INFO —    prec_at_5: 0.679963
INFO —    prec_at_8: 0.553301
INFO —     macro_f1: 0.655410
INFO —     micro_f1: 0.727384
INFO —    macro_auc: 0.933417
INFO —    micro_auc: 0.952115
INFO — Saving result on results/dcan_mimic3_50/test_result.json
```

MIMIC-III (top-50, old), with 2 level DCAN (training not complete):
```
Val (@ epoch 26)
2022-04-01 12:41:14,544 — src.trainers.base_trainer — INFO —    prec_at_5: 0.642721
2022-04-01 12:41:14,551 — src.trainers.base_trainer — INFO —    prec_at_8: 0.517721
2022-04-01 12:41:14,563 — src.trainers.base_trainer — INFO —     macro_f1: 0.564367
2022-04-01 12:41:14,574 — src.trainers.base_trainer — INFO —     micro_f1: 0.668651
2022-04-01 12:41:14,643 — src.trainers.base_trainer — INFO —    macro_auc: 0.906983
2022-04-01 12:41:14,663 — src.trainers.base_trainer — INFO —    micro_auc: 0.932760

Test (@ epoch 26)
2022-04-01 12:47:00,561 — src.trainers.base_trainer — INFO —    prec_at_5: 0.642684
2022-04-01 12:47:00,562 — src.trainers.base_trainer — INFO —    prec_at_8: 0.523641
2022-04-01 12:47:00,562 — src.trainers.base_trainer — INFO —     macro_f1: 0.560526
2022-04-01 12:47:00,562 — src.trainers.base_trainer — INFO —     micro_f1: 0.665048
2022-04-01 12:47:00,563 — src.trainers.base_trainer — INFO —    macro_auc: 0.905683
2022-04-01 12:47:00,563 — src.trainers.base_trainer — INFO —    micro_auc: 0.932133
```